### PR TITLE
Fix error when importing with typescript.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,1 @@
-declare module 'got-ssrf' {
-  export { Got as gotSsrf } from 'got'
-}
+declare module 'got-ssrf';


### PR DESCRIPTION
The existing definition causes this error when imported in typescript with `import { gotSsrf } from 'got-ssrf'`:

```'gotSsrf' only refers to a type, but is being used as a value here.```

Removing the export from `index.d.ts` fixes the issue.